### PR TITLE
Adding command line support for excluding columns on the basis of regex pattern

### DIFF
--- a/piicatcher/explorer/databases.py
+++ b/piicatcher/explorer/databases.py
@@ -48,6 +48,10 @@ match at least one -t switch but no -T switches. If -T appears without -t, then
 tables matching -T are excluded from what is otherwise a normal dump.
 """
 
+exclude_column_regex_help_text = """
+Do not dump any columns matching the table pattern.
+"""
+
 
 @click.command("db")
 @click.pass_context
@@ -92,6 +96,7 @@ tables matching -T are excluded from what is otherwise a normal dump.
 @click.option("-N", "--exclude-schema", multiple=True, help=exclude_schema_help_text)
 @click.option("-t", "--table", multiple=True, help=table_help_text)
 @click.option("-T", "--exclude-table", multiple=True, help=exclude_table_help_text)
+@click.option("-C", "--exclude-column-regex", multiple=True, help=exclude_column_regex_help_text)
 def cli(
     cxt,
     host,
@@ -108,6 +113,7 @@ def cli(
     exclude_schema,
     table,
     exclude_table,
+    exclude_column_regex,
 ):
     ns = Namespace(
         host=host,
@@ -123,6 +129,7 @@ def cli(
         exclude_schema=exclude_schema,
         include_table=table,
         exclude_table=exclude_table,
+        exclude_column_regex=exclude_column_regex,
     )
 
     if output_format is not None or output is not None:

--- a/piicatcher/explorer/explorer.py
+++ b/piicatcher/explorer/explorer.py
@@ -21,6 +21,7 @@ class Explorer(ABC):
         self._exclude_schema = ns.exclude_schema
         self._include_table = ns.include_table
         self._exclude_table = ns.exclude_table
+        self._exclude_column_regex = ns.exclude_column_regex
         self._database = Database(
             "database", include=self._include_schema, exclude=self._exclude_schema
         )
@@ -214,7 +215,7 @@ class Explorer(ABC):
                     elif current_table.get_name() != row[1]:
                         current_schema.add_child(current_table)
                         current_table = Table(current_schema, row[1])
-                    current_table.add_child(Column(row[2]))
+                    current_table.add_child(Column(row[2], exclude_regex=self._exclude_column_regex))
 
                     row = cursor.fetchone()
 

--- a/piicatcher/explorer/metadata.py
+++ b/piicatcher/explorer/metadata.py
@@ -133,9 +133,9 @@ class Table(NamedObject):
 
 
 class Column(NamedObject):
-    def __init__(self, name):
+    def __init__(self, name, exclude_regex=()):
         super(Column, self).__init__(name, (), ())
-        self.column_scanner = ColumnNameScanner()
+        self.column_scanner = ColumnNameScanner(exclude_regex)
 
     def add_pii_type(self, pii):
         self._pii.add(pii)

--- a/piicatcher/scanner.py
+++ b/piicatcher/scanner.py
@@ -8,7 +8,6 @@ from commonregex import CommonRegex
 
 from piicatcher.piitypes import PiiTypes
 
-
 # pylint: disable=too-few-public-methods
 class Scanner(ABC):
     """Scanner abstract class that defines required methods"""
@@ -65,6 +64,8 @@ class NERScanner(Scanner):
 
 
 class ColumnNameScanner(Scanner):
+    def __init__(self, exclude_regex=()):
+        self._exclude_regex = re.compile(exclude_regex[0], re.IGNORECASE)   # [0] cause the option comes as tuple
     regex = {
         PiiTypes.PERSON: re.compile(
             "^.*(firstname|fname|lastname|lname|"
@@ -92,7 +93,7 @@ class ColumnNameScanner(Scanner):
     def scan(self, text):
         types = set()
         for pii_type in self.regex:
-            if self.regex[pii_type].match(text) is not None:
+            if self.regex[pii_type].match(text) is not None and self._exclude_regex.match(text) is None:    # excluded_regex shouldn't match
                 types.add(pii_type)
 
         logging.debug("PiiTypes are %s", ",".join(str(x) for x in list(types)))


### PR DESCRIPTION
Now piicatcher can support excluding columns on the basis of regex pattern

```piicatcher --config config --catalog-format json db -n lake_last_mile --table view_order --exclude-column-regex "^.*(merchant|state).*$"```

![image](https://user-images.githubusercontent.com/17861054/102344660-3fb58c80-3fc2-11eb-83bb-841171c8a756.png)
